### PR TITLE
Implemented OAuth, added Plex Media Server calls, and reworked top-level API calls

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,11 +49,6 @@
             <version>${retrofit.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.squareup.retrofit2</groupId>
-            <artifactId>converter-simplexml</artifactId>
-            <version>${retrofit.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>4.4.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
             <version>${retrofit.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.retrofit2</groupId>
+            <artifactId>converter-simplexml</artifactId>
+            <version>${retrofit.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>4.4.4</version>
@@ -74,8 +79,8 @@
             <version>RELEASE</version>
         </dependency>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
             <version>RELEASE</version>
         </dependency>
     </dependencies>

--- a/src/main/java/com/teotas/plex/RetrofitClient.java
+++ b/src/main/java/com/teotas/plex/RetrofitClient.java
@@ -3,6 +3,7 @@ package com.teotas.plex;
 import com.google.common.base.Preconditions;
 import com.teotas.plex.interceptors.BasicAuthInterceptor;
 import com.teotas.plex.interceptors.OAuthInterceptor;
+import com.teotas.plex.interceptors.ResponseInterceptor;
 import lombok.Getter;
 import okhttp3.OkHttpClient;
 
@@ -19,8 +20,10 @@ public class RetrofitClient {
         Preconditions.checkNotNull(user, user.getLogin(), user.getPassword());
 
         BasicAuthInterceptor basicAuthInterceptor = new BasicAuthInterceptor(connection);
+        ResponseInterceptor responseInterceptor = new ResponseInterceptor(connection);
         return new OkHttpClient.Builder()
-                .addInterceptor(basicAuthInterceptor);
+                .addInterceptor(basicAuthInterceptor)
+                .addInterceptor(responseInterceptor);
     }
 
     public static OkHttpClient oAuthClient(PlexAPIConnection connection){
@@ -28,12 +31,14 @@ public class RetrofitClient {
     }
 
     private static OkHttpClient.Builder getOAuthClientBuilder(PlexAPIConnection connection){
-        String authTokenId = connection.getAuthToken();
-        Preconditions.checkNotNull(authTokenId);
+        PlexUser user = connection.getUser();
+        Preconditions.checkNotNull(user, user.getLogin(), user.getPassword());
 
         OAuthInterceptor oAuthInterceptor = new OAuthInterceptor(connection);
+        ResponseInterceptor responseInterceptor = new ResponseInterceptor(connection);
         return new OkHttpClient.Builder()
-                .addInterceptor(oAuthInterceptor);
+                .addInterceptor(oAuthInterceptor)
+                .addInterceptor(responseInterceptor);
 
     }
 }

--- a/src/main/java/com/teotas/plex/client/api/MediaServerAPI.java
+++ b/src/main/java/com/teotas/plex/client/api/MediaServerAPI.java
@@ -7,10 +7,7 @@ import com.teotas.plex.RetrofitClient;
 import com.teotas.plex.client.api.endpoints.MediaServerEndpoints;
 import com.teotas.plex.client.api.models.plexobjects.User;
 import retrofit2.Retrofit;
-import retrofit2.converter.simplexml.SimpleXmlConverterFactory;
-
 import java.util.ArrayList;
-import java.util.List;
 
 public class MediaServerAPI {
     private MediaServerEndpoints endpoints;

--- a/src/main/java/com/teotas/plex/client/api/MediaServerAPI.java
+++ b/src/main/java/com/teotas/plex/client/api/MediaServerAPI.java
@@ -1,0 +1,30 @@
+package com.teotas.plex.client.api;
+
+import com.teotas.plex.APICall;
+import com.teotas.plex.PlexAPIConnection;
+import com.teotas.plex.PlexRetrofitFactory;
+import com.teotas.plex.RetrofitClient;
+import com.teotas.plex.client.api.endpoints.MediaServerEndpoints;
+import com.teotas.plex.client.api.models.plexobjects.User;
+import retrofit2.Retrofit;
+import retrofit2.converter.simplexml.SimpleXmlConverterFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MediaServerAPI {
+    private MediaServerEndpoints endpoints;
+
+    public MediaServerAPI(PlexAPIConnection connection){
+        Retrofit retrofit = PlexRetrofitFactory.createJsonBuilder()
+                .client(RetrofitClient.oAuthClient(connection))
+                .build();
+        endpoints = retrofit.create(MediaServerEndpoints.class);
+    }
+
+    public ArrayList<User> getFriendsList(){
+        return new APICall<>(
+                endpoints.getAllFriends()
+        ).makeRequest().getMediaContainer().getUsers();
+    }
+}

--- a/src/main/java/com/teotas/plex/client/api/PlexAPI.java
+++ b/src/main/java/com/teotas/plex/client/api/PlexAPI.java
@@ -1,0 +1,27 @@
+package com.teotas.plex.client.api;
+
+import com.teotas.plex.PlexAPIConnection;
+
+public class PlexAPI {
+    private PlexAPIConnection connection;
+    private LoginAPI loginAPI;
+    private MediaServerAPI mediaServerAPI;
+
+    public PlexAPI (PlexAPIConnection connection) {
+        this.connection = connection;
+    }
+
+    public LoginAPI loginAPI(){
+        if(loginAPI == null){
+            loginAPI = new LoginAPI(connection);
+        }
+        return loginAPI;
+    }
+
+    public MediaServerAPI mediaServerAPI(){
+        if(mediaServerAPI == null){
+            mediaServerAPI = new MediaServerAPI(connection);
+        }
+        return mediaServerAPI;
+    }
+}

--- a/src/main/java/com/teotas/plex/client/api/endpoints/MediaServerEndpoints.java
+++ b/src/main/java/com/teotas/plex/client/api/endpoints/MediaServerEndpoints.java
@@ -1,0 +1,22 @@
+package com.teotas.plex.client.api.endpoints;
+
+import com.teotas.plex.client.api.models.MediaServerResponse;
+import com.teotas.plex.client.api.models.PlexResponse;
+import retrofit2.Call;
+import retrofit2.http.GET;
+
+public interface MediaServerEndpoints {
+
+    @GET("pms/friends/all")
+    Call<PlexResponse<MediaServerResponse>> getAllFriends();
+
+    @GET("pms/friends/requests")
+    Call<PlexResponse<MediaServerResponse>> getPendingFriends();
+
+    @GET("pms/playlists/queue/unwatched")
+    Call<PlexResponse<MediaServerResponse>> getUnwatchedPlaylist();
+
+    @GET("pms/playlists/recommendations/unwatched")
+    Call<PlexResponse<MediaServerResponse>> getRecommendedUnwatchedPlaylist();
+
+}

--- a/src/main/java/com/teotas/plex/client/api/models/MediaServerResponse.java
+++ b/src/main/java/com/teotas/plex/client/api/models/MediaServerResponse.java
@@ -1,0 +1,20 @@
+package com.teotas.plex.client.api.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.teotas.plex.client.api.models.plexobjects.User;
+import lombok.Getter;
+
+import java.util.ArrayList;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MediaServerResponse {
+    String identifier;
+    int totalSize;
+    int size;
+    String machineIdentifier;
+    String friendlyName;
+    @JsonProperty("User")
+    ArrayList<User> users;
+}

--- a/src/main/java/com/teotas/plex/client/api/models/PlexResponse.java
+++ b/src/main/java/com/teotas/plex/client/api/models/PlexResponse.java
@@ -20,7 +20,6 @@ import java.util.List;
 @JsonInclude(Include.NON_NULL)
 public class PlexResponse<V> {
 
-    //JSON Elements
     @JsonProperty("user")
     private LoginResponse loginInfo;
 

--- a/src/main/java/com/teotas/plex/client/api/models/PlexResponse.java
+++ b/src/main/java/com/teotas/plex/client/api/models/PlexResponse.java
@@ -4,12 +4,26 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.teotas.plex.client.api.models.plexobjects.User;
 import lombok.Getter;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementArray;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Root;
+import retrofit2.http.Path;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @JsonIgnoreProperties(ignoreUnknown=true)
 @JsonInclude(Include.NON_NULL)
-public class PlexResponse {
+public class PlexResponse<V> {
+
+    //JSON Elements
     @JsonProperty("user")
-    LoginResponse loginInfo;
+    private LoginResponse loginInfo;
+
+    @JsonProperty("MediaContainer")
+    private V mediaContainer;
 }

--- a/src/main/java/com/teotas/plex/client/api/models/plexobjects/Server.java
+++ b/src/main/java/com/teotas/plex/client/api/models/plexobjects/Server.java
@@ -1,0 +1,17 @@
+package com.teotas.plex.client.api.models.plexobjects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import org.simpleframework.xml.Attribute;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown=true)
+public class Server {
+    private long id;
+    private long serverId;
+    private String machineIdentifier;
+    private String name;
+    private long lastSeenAt;
+    private byte numLibraries;
+    private byte owned;
+}

--- a/src/main/java/com/teotas/plex/client/api/models/plexobjects/User.java
+++ b/src/main/java/com/teotas/plex/client/api/models/plexobjects/User.java
@@ -1,0 +1,20 @@
+package com.teotas.plex.client.api.models.plexobjects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class User {
+
+    private long id;
+    private String title;
+    private String username;
+    private String email;
+    private String recommendationsPlaylistId;
+    @JsonProperty("thumb")
+    private String thumbnail;
+    @JsonProperty("Server")
+    private Server server;
+
+}

--- a/src/main/java/com/teotas/plex/interceptors/OAuthInterceptor.java
+++ b/src/main/java/com/teotas/plex/interceptors/OAuthInterceptor.java
@@ -1,6 +1,7 @@
 package com.teotas.plex.interceptors;
 
 import com.teotas.plex.PlexAPIConnection;
+import com.teotas.plex.client.api.LoginAPI;
 import lombok.extern.slf4j.Slf4j;
 import okhttp3.Interceptor;
 import okhttp3.Request;
@@ -21,7 +22,7 @@ public class OAuthInterceptor implements Interceptor {
 
         Request.Builder requestBuilder = original.newBuilder()
                 .header("Content-Type", "application/json")
-                .header(RequiredPlexHeader.PLEX_TOKEN.header(), connection.getAuthToken())
+                .header(RequiredPlexHeader.PLEX_TOKEN.header(), getAuthToken())
                 .header(RequiredPlexHeader.PLEX_CLIENT_ID.header(), "PLEXRETROFITAPIV1" )
                 .header(RequiredPlexHeader.PLEX_PRODUCT.header(),"Plex Retrofit API" )
                 .header(RequiredPlexHeader.PLEX_VERSION.header(),"V1")
@@ -31,5 +32,13 @@ public class OAuthInterceptor implements Interceptor {
         Request updatedRequest = requestBuilder.build();
 
         return chain.proceed(updatedRequest);
+    }
+
+    private String getAuthToken(){
+        //TODO implement session check if necessary
+        if(connection.getAuthToken() == null){
+            connection.setAuthToken(new LoginAPI(connection).login().getAuthToken());
+        }
+        return connection.getAuthToken();
     }
 }

--- a/src/main/java/com/teotas/plex/interceptors/ResponseInterceptor.java
+++ b/src/main/java/com/teotas/plex/interceptors/ResponseInterceptor.java
@@ -19,15 +19,15 @@ public class ResponseInterceptor implements Interceptor {
     public Response intercept(Chain chain) throws IOException {
         Request original = chain.request();
 
-        Response reqResponse = chain.proceed(original);
+        Response returnedResponse = chain.proceed(original);
 
-        if(reqResponse.header("Content-Type").toLowerCase().contains("xml")){
-            String xmlToConvert = reqResponse.body().string();
+        if(returnedResponse.header("Content-Type").toLowerCase().contains("xml")){
+            String xmlToConvert = returnedResponse.body().string();
             JSONObject convertedXML = XML.toJSONObject(xmlToConvert);
             ResponseBody newBody = ResponseBody.create(MediaType.parse("application/json"), convertedXML.toString());
-            reqResponse = reqResponse.newBuilder().body(newBody).build();
+            returnedResponse = returnedResponse.newBuilder().body(newBody).build();
         }
 
-        return reqResponse;
+        return returnedResponse;
     }
 }

--- a/src/main/java/com/teotas/plex/interceptors/ResponseInterceptor.java
+++ b/src/main/java/com/teotas/plex/interceptors/ResponseInterceptor.java
@@ -1,0 +1,33 @@
+package com.teotas.plex.interceptors;
+
+import com.teotas.plex.PlexAPIConnection;
+import okhttp3.*;
+import org.json.JSONObject;
+import org.json.XML;
+
+import java.io.IOException;
+
+
+
+public class ResponseInterceptor implements Interceptor {
+    private PlexAPIConnection connection;
+
+    public ResponseInterceptor(PlexAPIConnection connection){
+        this.connection = connection;
+    }
+
+    public Response intercept(Chain chain) throws IOException {
+        Request original = chain.request();
+
+        Response reqResponse = chain.proceed(original);
+
+        if(reqResponse.header("Content-Type").toLowerCase().contains("xml")){
+            String xmlToConvert = reqResponse.body().string();
+            JSONObject convertedXML = XML.toJSONObject(xmlToConvert);
+            ResponseBody newBody = ResponseBody.create(MediaType.parse("application/json"), convertedXML.toString());
+            reqResponse = reqResponse.newBuilder().body(newBody).build();
+        }
+
+        return reqResponse;
+    }
+}

--- a/src/test/java/com/teotas/plex/client/api/PlexClientTest.java
+++ b/src/test/java/com/teotas/plex/client/api/PlexClientTest.java
@@ -3,16 +3,20 @@ package com.teotas.plex.client.api;
 import com.teotas.plex.PlexAPIConnection;
 import com.teotas.plex.PlexUser;
 import com.teotas.plex.client.api.models.LoginResponse;
+import com.teotas.plex.client.api.models.plexobjects.User;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 
 public class PlexClientTest {
     private static PlexUser testUser;
-    private static LoginAPI plexAuthAPI;
+    private static PlexAPI plex;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
@@ -26,13 +30,19 @@ public class PlexClientTest {
         PlexAPIConnection testConnection = PlexAPIConnection.builder()
                 .user(testUser).build();
 
-        plexAuthAPI = new LoginAPI(testConnection);
+        plex = new PlexAPI(testConnection);
     }
 
     @Test
     public void login(){
-        LoginResponse loginInfo = plexAuthAPI.login();
+        LoginResponse loginInfo = plex.loginAPI().login();
         Assert.assertEquals(loginInfo.getUsername(), System.getenv("LOGIN"));
+    }
+
+    @Test
+    public void getAllFriends(){
+        List<User> friends = plex.mediaServerAPI().getFriendsList();
+        Assert.assertTrue(!friends.isEmpty());
     }
 
 }

--- a/src/test/java/com/teotas/plex/client/api/PlexClientTest.java
+++ b/src/test/java/com/teotas/plex/client/api/PlexClientTest.java
@@ -11,7 +11,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
-import java.util.List;
 
 
 public class PlexClientTest {
@@ -41,7 +40,7 @@ public class PlexClientTest {
 
     @Test
     public void getAllFriends(){
-        List<User> friends = plex.mediaServerAPI().getFriendsList();
+        ArrayList<User> friends = plex.mediaServerAPI().getFriendsList();
         Assert.assertTrue(!friends.isEmpty());
     }
 


### PR DESCRIPTION
In order to use the API, the user is no longer required to initialize an API per group of calls (i.e. LoginAPI, MediaServerAPI), instead they can initialize the PlexAPI and have access to lazy-loaded apis as needed.